### PR TITLE
Update B_Data_Analysis_Questions.sql

### DIFF
--- a/Case Study #3 - Foodie-Fi/SQL/B_Data_Analysis_Questions.sql
+++ b/Case Study #3 - Foodie-Fi/SQL/B_Data_Analysis_Questions.sql
@@ -156,13 +156,17 @@ WITH join_date AS (
 	           GROUP  BY customer_id, start_date
                   ),
       buckets AS ( 
-	          SELECT WIDTH_BUCKET(upgrade_date - join_date, 0, 360, 12) AS bucket,
+	          SELECT CASE 
+				WHEN upgrade_date - join_date = 0
+					THEN 1
+				ELSE WIDTH_BUCKET(upgrade_date - join_date, 1, 361, 12)
+				END AS bucket,
 	                 COUNT(u.customer_id) AS customer_count,
                          ROUND(AVG(CAST(u.upgrade_date - j.join_date AS DECIMAL)), 0) AS average_days
 	          FROM   join_date AS j
 	          JOIN   upgrade_date AS u
 	          ON     j.customer_id = u.customer_id
-	          GROUP  BY WIDTH_BUCKET(upgrade_date - join_date, 0, 360, 12)
+	          GROUP  BY bucket
 	          ORDER BY bucket
                  )
 SELECT CASE 


### PR DESCRIPTION
-- 10. Can you further breakdown this average value into 30 day periods (i.e. 0-30 days, 31-60 days etc)
In the above question bucket was declared as WIDTH_BUCKET(upgrade_date - join_date, 0, 360, 12) which was taking range values as below
-> 0-29, 30-59, 60-89,........,330-359
-> So a customer with customer_id =  473 with difference in upgrade and join date = 30 days was showing up in bucket 2 instead of 1

Solution is to use WIDTH_BUCKET(upgrade_date - join_date, 1, 361, 12) and a separate case for days = 0